### PR TITLE
fix: add missing line within :Fabrication restrictions in ttl file

### DIFF
--- a/PRIMA/experiment/ver_2_0/prima-experiment.ttl
+++ b/PRIMA/experiment/ver_2_0/prima-experiment.ttl
@@ -325,6 +325,7 @@ core:ResearchUser a owl:Class ;
         [ a owl:Restriction ;
             owl:onProperty <https://w3id.org/pmd/co/output> ;
             owl:someValuesFrom :Precursor ],
+        [ a owl:Restriction ;
             owl:onProperty core:usesEquipment ;
             owl:someValuesFrom core:Equipment ],
         [ a owl:Restriction ;


### PR DESCRIPTION
Hi everyone,

when using the turtle serialization of the prima-experiment module in a project, my parser complained with a syntax error. Inserting this line resolves this, and I think this change seems to be the intended content.

With kind regards,
Fabian